### PR TITLE
Improve bastion EBS security

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ module "bastion" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.71.0 |
 
 ## Modules
 
@@ -114,7 +114,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_ssh_commands"></a> [allow\_ssh\_commands](#input\_allow\_ssh\_commands) | Allows the SSH user to execute one-off commands. Pass true to enable. Warning: These commands are not logged and increase the vulnerability of the system. Use at your own discretion. | `bool` | `false` | no |
-| <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | n/a | `bool` | `true` | no |
+| <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | n/a | `bool` | `false` | no |
 | <a name="input_auto_scaling_group_subnets"></a> [auto\_scaling\_group\_subnets](#input\_auto\_scaling\_group\_subnets) | List of subnets where the Auto Scaling Group will deploy the instances | `list(string)` | n/a | yes |
 | <a name="input_bastion_additional_security_groups"></a> [bastion\_additional\_security\_groups](#input\_bastion\_additional\_security\_groups) | List of additional security groups to attach to the launch template | `list(string)` | `[]` | no |
 | <a name="input_bastion_ami"></a> [bastion\_ami](#input\_bastion\_ami) | The AMI that the Bastion Host will use. | `string` | `""` | no |
@@ -129,11 +129,12 @@ No modules.
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | The bucket and all objects should be destroyed when using true | `bool` | `false` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name where the bastion will store the logs | `string` | n/a | yes |
 | <a name="input_bucket_versioning"></a> [bucket\_versioning](#input\_bucket\_versioning) | Enable bucket versioning or not | `bool` | `true` | no |
-| <a name="input_cidrs"></a> [cidrs](#input\_cidrs) | List of CIDRs that can access the bastion. Default: 0.0.0.0/0 | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_cidrs"></a> [cidrs](#input\_cidrs) | List of CIDRs that can access the bastion. Default: 0.0.0.0/0 | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_create_dns_record"></a> [create\_dns\_record](#input\_create\_dns\_record) | Choose if you want to create a record name for the bastion (LB). If true, 'hosted\_zone\_id' and 'bastion\_record\_name' are mandatory | `bool` | n/a | yes |
-| <a name="input_create_elb"></a> [create\_elb](#input\_create\_elb) | Choose if you want to deploy an ELB for accessing bastion hosts. Only select false if there is no need to SSH into bastion from outside. If true, you must set elb\_subnets and is\_lb\_private | `bool` | `true` | no |
+| <a name="input_create_elb"></a> [create\_elb](#input\_create\_elb) | Choose if you want to deploy an ELB for accessing bastion hosts. If true, you must set elb\_subnets and is\_lb\_private | `bool` | `true` | no |
 | <a name="input_disk_encrypt"></a> [disk\_encrypt](#input\_disk\_encrypt) | Instance EBS encryption | `bool` | `true` | no |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Root EBS size in GB | `number` | `8` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | EBS volume type | `string` | `"gp3"` | no |
 | <a name="input_elb_subnets"></a> [elb\_subnets](#input\_elb\_subnets) | List of subnets where the ELB will be deployed | `list(string)` | `[]` | no |
 | <a name="input_enable_http_protocol_ipv6"></a> [enable\_http\_protocol\_ipv6](#input\_enable\_http\_protocol\_ipv6) | Enables or disables the IPv6 endpoint for the instance metadata service | `bool` | `false` | no |
 | <a name="input_enable_instance_metadata_tags"></a> [enable\_instance\_metadata\_tags](#input\_enable\_instance\_metadata\_tags) | Enables or disables access to instance tags from the instance metadata service | `bool` | `false` | no |
@@ -143,7 +144,7 @@ No modules.
 | <a name="input_http_endpoint"></a> [http\_endpoint](#input\_http\_endpoint) | Whether the metadata service is available | `bool` | `true` | no |
 | <a name="input_http_put_response_hop_limit"></a> [http\_put\_response\_hop\_limit](#input\_http\_put\_response\_hop\_limit) | The desired HTTP PUT response hop limit for instance metadata requests | `number` | `1` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance size of the bastion | `string` | `"t3.nano"` | no |
-| <a name="input_ipv6_cidrs"></a> [ipv6\_cidrs](#input\_ipv6\_cidrs) | List of IPv6 CIDRs that can access the bastion. Default: ::/0 | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
+| <a name="input_ipv6_cidrs"></a> [ipv6\_cidrs](#input\_ipv6\_cidrs) | List of IPv6 CIDRs that can access the bastion. Default: ::/0 | `list(string)` | <pre>[<br/>  "::/0"<br/>]</pre> | no |
 | <a name="input_is_lb_private"></a> [is\_lb\_private](#input\_is\_lb\_private) | If TRUE, the load balancer scheme will be "internal" else "internet-facing" | `bool` | `null` | no |
 | <a name="input_kms_enable_key_rotation"></a> [kms\_enable\_key\_rotation](#input\_kms\_enable\_key\_rotation) | Enable key rotation for the KMS key | `bool` | `false` | no |
 | <a name="input_log_auto_clean"></a> [log\_auto\_clean](#input\_log\_auto\_clean) | Enable or disable the lifecycle | `bool` | `false` | no |
@@ -152,9 +153,9 @@ No modules.
 | <a name="input_log_standard_ia_days"></a> [log\_standard\_ia\_days](#input\_log\_standard\_ia\_days) | Number of days before moving logs to IA Storage | `number` | `30` | no |
 | <a name="input_private_ssh_port"></a> [private\_ssh\_port](#input\_private\_ssh\_port) | Set the SSH port to use between the bastion and private instance | `number` | `22` | no |
 | <a name="input_public_ssh_port"></a> [public\_ssh\_port](#input\_public\_ssh\_port) | Set the SSH port to use from desktop to the bastion | `number` | `22` | no |
-| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign | `map(string)` | `{}` | no |
-| <a name="input_use_imds_v2"></a> [use\_imds\_v2](#input\_use\_imds\_v2) | Use (IMDSv2) Instance Metadata Service V2 | `bool` | `false` | no |
+| <a name="input_use_imds_v2"></a> [use\_imds\_v2](#input\_use\_imds\_v2) | Use (IMDSv2) Instance Metadata Service V2 | `bool` | `true` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where we'll deploy the bastion | `string` | n/a | yes |
 
 ## Outputs
@@ -174,6 +175,14 @@ No modules.
 | <a name="output_target_group_arn"></a> [target\_group\_arn](#output\_target\_group\_arn) | The ARN of the target group for the ELB |
 <!-- END_TF_DOCS -->
 
+## Updates
+
+This Terraform documentation can be automatically regenerated with:
+
+```
+terraform-docs markdown table --output-file README.md --output-mode inject .
+```
+
 Known issues
 ------------
 
@@ -186,7 +195,7 @@ Auto Scaling Groups -> Instance refresh . Keep in mind all data from instance wi
 Authors
 -------
 
-Module managed by [Guimove](https://github.com/Guimove).
+Module forked from [Guimove](https://github.com/Guimove).
 
 License
 -------

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,4 @@
-data "aws_ami" "amazon-linux-2" {
+data "aws_ami" "amazon_linux_2" {
   most_recent = true
   owners      = ["amazon"]
   name_regex  = "^amzn2-ami-hvm.*-ebs"
@@ -7,6 +7,18 @@ data "aws_ami" "amazon-linux-2" {
     name   = "architecture"
     values = ["x86_64"]
   }
+}
+
+data "aws_ami" "custom_ami" {
+  count = var.bastion_ami == "" ? 0 : 1
+  filter {
+    name   = "image-id"
+    values = [var.bastion_ami]
+  }
+}
+
+locals {
+  bastion_ami = var.bastion_ami == "" ? data.aws_ami.amazon_linux_2 : data.aws_ami.custom_ami[0]
 }
 
 data "aws_subnet" "subnets" {

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ data "aws_kms_alias" "kms-ebs" {
 resource "aws_s3_object" "bucket_public_keys_readme" {
   bucket     = aws_s3_bucket.bucket.id
   key        = "public-keys/README.txt"
-  content    = "Drop here the ssh public keys of the instances you want to control"
+  content    = "Drop the SSH public keys of the instances you want to control here"
   kms_key_id = aws_kms_key.key.arn
 }
 
@@ -131,7 +131,6 @@ data "aws_iam_policy_document" "bastion_host_policy_document" {
     ]
     resources = [aws_kms_key.key.arn]
   }
-
 }
 
 resource "aws_iam_policy" "bastion_host_policy" {
@@ -213,7 +212,7 @@ resource "aws_iam_instance_profile" "bastion_host_profile" {
 
 resource "aws_launch_template" "bastion_launch_template" {
   name_prefix            = local.name_prefix
-  image_id               = var.bastion_ami != "" ? var.bastion_ami : data.aws_ami.amazon-linux-2.id
+  image_id               = local.bastion_ami.id
   instance_type          = var.instance_type
   update_default_version = true
   monitoring {
@@ -238,14 +237,17 @@ resource "aws_launch_template" "bastion_launch_template" {
     sync_logs_cron_job      = var.enable_logs_s3_sync ? "*/5 * * * * /usr/bin/bastion/sync_s3" : ""
   }))
 
-  block_device_mappings {
-    device_name = "/dev/xvda"
-    ebs {
-      volume_size           = var.disk_size
-      volume_type           = "gp2"
-      delete_on_termination = true
-      encrypted             = var.disk_encrypt
-      kms_key_id            = var.disk_encrypt ? data.aws_kms_alias.kms-ebs.target_key_arn : ""
+  dynamic "block_device_mappings" {
+    for_each = local.bastion_ami.block_device_mappings
+    content {
+      device_name = block_device_mappings.value.device_name
+      ebs {
+        volume_size           = try(block_device_mappings.value.ebs.volume_size, var.disk_size)
+        volume_type           = try(block_device_mappings.value.ebs.volume_type, var.disk_type)
+        delete_on_termination = true
+        encrypted             = var.disk_encrypt
+        kms_key_id            = var.disk_encrypt ? data.aws_kms_alias.kms-ebs.target_key_arn : ""
+      }
     }
   }
 
@@ -273,7 +275,7 @@ resource "aws_launch_template" "bastion_launch_template" {
 }
 
 resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
-  name_prefix = "ASG-${local.name_prefix}"
+  name_prefix = local.name_prefix
   launch_template {
     id      = aws_launch_template.bastion_launch_template.id
     version = aws_launch_template.bastion_launch_template.latest_version
@@ -308,7 +310,7 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
 
   tag {
     key                 = "Name"
-    value               = "ASG-${local.name_prefix}"
+    value               = local.name_prefix
     propagate_at_launch = true
   }
 

--- a/main.tf
+++ b/main.tf
@@ -322,5 +322,8 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
     create_before_destroy = true
   }
 
-  depends_on = [aws_s3_bucket.bucket]
+  depends_on = [
+    aws_s3_bucket.bucket,
+    aws_launch_template.bastion_launch_template
+  ]
 }

--- a/user_data.sh
+++ b/user_data.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -x
-yum -y update --security
 
 ##########################
 ## ENABLE SSH RECORDING ##
@@ -8,8 +7,8 @@ yum -y update --security
 # Create a new folder for the log files
 mkdir /var/log/bastion
 
-# Allow ec2-user only to access this folder and its content
-chown ec2-user:ec2-user /var/log/bastion
+# Allow ubuntu only to access this folder and its content
+chown ubuntu:ubuntu /var/log/bastion
 chmod -R 770 /var/log/bastion
 setfacl -Rdm other:0 /var/log/bastion
 
@@ -70,7 +69,7 @@ chmod a+x /usr/bin/bastion/shell
 # 1. Add a random suffix to the log file name.
 # 2. Prevent bastion host users from listing the folder containing log files. This is done
 #    by changing the group owner of "script" and setting GID.
-chown root:ec2-user /usr/bin/script
+chown root:ubuntu /usr/bin/script
 chmod g+s /usr/bin/script
 
 # 3. Prevent bastion host users from viewing processes owned by other users, because the log
@@ -167,25 +166,6 @@ EOF
 
 chmod 700 /usr/bin/bastion/sync_users
 
-##############################
-## INSTALL SECURITY UPDATES ##
-##############################
-
-# Security updates are installed by yum. If script is updated (package util-linux)
-# then the setuid bit needs to be recovered. Otherwise clients can not loging.
-
-cat > /usr/bin/bastion/yum_update << 'EOF'
-#!/usr/bin/env bash
-
-yum -y update --security
-
-chown root:ec2-user /usr/bin/script
-chmod g+s /usr/bin/script
-
-EOF
-
-chmod 700 /usr/bin/bastion/yum_update
-
 
 ###########################################
 ## SCHEDULE SCRIPTS AND SECURITY UPDATES ##
@@ -193,7 +173,6 @@ chmod 700 /usr/bin/bastion/yum_update
 
 cat > ~/mycron << EOF
 */5 * * * * /usr/bin/bastion/sync_users
-0 0 * * * /usr/bin/bastion/yum_update
 ${sync_logs_cron_job}
 EOF
 crontab ~/mycron

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "allow_ssh_commands" {
 
 variable "associate_public_ip_address" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "auto_scaling_group_subnets" {
@@ -119,6 +119,12 @@ variable "disk_size" {
   type        = number
   description = "Root EBS size in GB"
   default     = 8
+}
+
+variable "disk_type" {
+  type        = string
+  description = "EBS volume type"
+  default     = "gp3"
 }
 
 variable "elb_subnets" {
@@ -234,7 +240,8 @@ variable "public_ssh_port" {
 }
 
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS region"
 }
 
 variable "tags" {
@@ -246,7 +253,7 @@ variable "tags" {
 variable "use_imds_v2" {
   type        = bool
   description = "Use (IMDSv2) Instance Metadata Service V2"
-  default     = false
+  default     = true
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
### Issues Closed

- PARA-11834

### Brief Summary

Adds ability to encrypt all EBS volumes on bastion AMI not just one.

### Detailed Summary

The forked repo is still the most used for AWS bastion creation but appears to be have been abandoned by the maintainer. These changes improve the EBS volume security, fix ASG naming conventions and remove Amazon Linux assumptions from user-data.

### Changes

- apply `block_device_mappings` to all volumes on AMI instead of single hardcoded device
- changed ASG resource names to use same name prefix as other resources
- removed `yum` usage from EC2 user-data script
- updated documentation to reflect above
