### PR TITLE
fix: standardized resource naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ No modules.
 | [aws_security_group_rule.egress_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_ami.amazon-linux-2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.custom_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.assume_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bastion_host_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_alias.kms-ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
@@ -151,6 +152,7 @@ No modules.
 | <a name="input_log_expiry_days"></a> [log\_expiry\_days](#input\_log\_expiry\_days) | Number of days before logs expiration | `number` | `90` | no |
 | <a name="input_log_glacier_days"></a> [log\_glacier\_days](#input\_log\_glacier\_days) | Number of days before moving logs to Glacier | `number` | `60` | no |
 | <a name="input_log_standard_ia_days"></a> [log\_standard\_ia\_days](#input\_log\_standard\_ia\_days) | Number of days before moving logs to IA Storage | `number` | `30` | no |
+| <a name="input_name"></a> [name](#input\_name) | Default name to use for resources | `string` | `null` | no |
 | <a name="input_private_ssh_port"></a> [private\_ssh\_port](#input\_private\_ssh\_port) | Set the SSH port to use between the bastion and private instance | `number` | `22` | no |
 | <a name="input_public_ssh_port"></a> [public\_ssh\_port](#input\_public\_ssh\_port) | Set the SSH port to use from desktop to the bastion | `number` | `22` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |

--- a/buckets.tf
+++ b/buckets.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "bucket" {
   bucket        = var.bucket_name
   force_destroy = var.bucket_force_destroy
-  tags          = merge(var.tags)
+  tags          = local.tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,8 @@
 locals {
-  name_prefix    = var.bastion_launch_template_name
+  name_prefix    = coalesce(var.name, var.bastion_launch_template_name)
   security_group = join("", flatten([aws_security_group.bastion_host_security_group[*].id, var.bastion_security_group_id]))
+
+  tags = merge(tomap({ "Name" = local.name_prefix }), merge(var.tags))
 
   // the compact() function checks for null values and gets rid of them 
   // the length is a check to ensure we dont have an empty array, as an empty array would throw an error for the cidr_block argument 

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,12 @@ variable "log_standard_ia_days" {
   default     = 30
 }
 
+variable "name" {
+  type        = string
+  description = "Default name to use for resources"
+  default     = null
+}
+
 variable "private_ssh_port" {
   type        = number
   description = "Set the SSH port to use between the bastion and private instance"


### PR DESCRIPTION
The use of names, prefixes and tags were inconsistent across resources. This standardizes them so all resources have similar names. This makes finding and grouping resources easier in the Console and also better meets service naming policy requirements.