### PR TITLE
S3 bucket policies and default AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ module "bastion" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.4 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.71.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -92,9 +92,8 @@ No modules.
 | [aws_lb_target_group.bastion_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_route53_record.bastion_record_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_lifecycle_configuration.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_ownership_controls.bucket-acl-ownership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_object.bucket_public_keys_readme](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
@@ -151,7 +150,9 @@ No modules.
 | <a name="input_log_auto_clean"></a> [log\_auto\_clean](#input\_log\_auto\_clean) | Enable or disable the lifecycle | `bool` | `false` | no |
 | <a name="input_log_expiry_days"></a> [log\_expiry\_days](#input\_log\_expiry\_days) | Number of days before logs expiration | `number` | `90` | no |
 | <a name="input_log_glacier_days"></a> [log\_glacier\_days](#input\_log\_glacier\_days) | Number of days before moving logs to Glacier | `number` | `60` | no |
+| <a name="input_log_incomplete_multipart_days"></a> [log\_incomplete\_multipart\_days](#input\_log\_incomplete\_multipart\_days) | Number of days after which incomplete multipart uploads (partial files) are aborted and cleaned up | `number` | `7` | no |
 | <a name="input_log_standard_ia_days"></a> [log\_standard\_ia\_days](#input\_log\_standard\_ia\_days) | Number of days before moving logs to IA Storage | `number` | `30` | no |
+| <a name="input_log_version_days"></a> [log\_version\_days](#input\_log\_version\_days) | Number of days before removing previous versions of logs | `number` | `30` | no |
 | <a name="input_name"></a> [name](#input\_name) | Default name to use for resources | `string` | `null` | no |
 | <a name="input_private_ssh_port"></a> [private\_ssh\_port](#input\_private\_ssh\_port) | Set the SSH port to use between the bastion and private instance | `number` | `22` | no |
 | <a name="input_public_ssh_port"></a> [public\_ssh\_port](#input\_public\_ssh\_port) | Set the SSH port to use from desktop to the bastion | `number` | `22` | no |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ No modules.
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_public_access_block.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_object.bucket_public_keys_readme](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
@@ -126,6 +127,7 @@ No modules.
 | <a name="input_bastion_launch_template_name"></a> [bastion\_launch\_template\_name](#input\_bastion\_launch\_template\_name) | Bastion Launch template Name, will also be used for the ASG | `string` | `"bastion-lt"` | no |
 | <a name="input_bastion_record_name"></a> [bastion\_record\_name](#input\_bastion\_record\_name) | DNS record name to use for the bastion | `string` | `""` | no |
 | <a name="input_bastion_security_group_id"></a> [bastion\_security\_group\_id](#input\_bastion\_security\_group\_id) | Custom security group to use | `string` | `""` | no |
+| <a name="input_bastion_ssh_user"></a> [bastion\_ssh\_user](#input\_bastion\_ssh\_user) | Default SSH user for the bastion AMI (e.g. ec2-user for Amazon Linux, ubuntu for Ubuntu) | `string` | `"ubuntu"` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | The bucket and all objects should be destroyed when using true | `bool` | `false` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name where the bastion will store the logs | `string` | n/a | yes |
 | <a name="input_bucket_versioning"></a> [bucket\_versioning](#input\_bucket\_versioning) | Enable bucket versioning or not | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ No modules.
 | [aws_security_group_rule.egress_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.custom_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.assume_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bastion_host_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/buckets.tf
+++ b/buckets.tf
@@ -15,17 +15,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "bucket" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-
-  depends_on = [aws_s3_bucket_ownership_controls.bucket-acl-ownership]
-}
-
-resource "aws_s3_bucket_ownership_controls" "bucket-acl-ownership" {
+# Disable ACLs (recommended). Bucket remains private; only owner has access.
+resource "aws_s3_bucket_ownership_controls" "bucket" {
   bucket = aws_s3_bucket.bucket.id
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "BucketOwnerEnforced"
   }
 }
 
@@ -60,6 +54,19 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
     expiration {
       days = var.log_expiry_days
+    }
+
+    # Remove prior object versions after this many days to prevent unbounded growth
+    noncurrent_version_expiration {
+      noncurrent_days = var.log_version_days
+    }
+
+    # Remove delete markers once all noncurrent versions are expired
+    expired_object_delete_marker = true
+
+    # Abort incomplete multipart uploads (partial files) after this many days
+    abort_incomplete_multipart_upload {
+      days_after_initiation = var.log_incomplete_multipart_days
     }
   }
 }

--- a/buckets.tf
+++ b/buckets.tf
@@ -62,8 +62,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
     }
 
     expiration {
-      days                         = var.log_expiry_days
-      expired_object_delete_marker = true
+      days = var.log_expiry_days
     }
 
     # Remove prior object versions after this many days to prevent unbounded growth
@@ -74,6 +73,20 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
     # Abort incomplete multipart uploads (partial files) after this many days
     abort_incomplete_multipart_upload {
       days_after_initiation = var.log_incomplete_multipart_days
+    }
+  }
+
+  # Remove delete markers once all noncurrent versions are expired (separate rule: expiration allows only one of days/date/expired_object_delete_marker)
+  rule {
+    id     = "log-delete-markers"
+    status = var.enable_logs_s3_sync && var.log_auto_clean ? "Enabled" : "Disabled"
+
+    filter {
+      prefix = "logs/"
+    }
+
+    expiration {
+      expired_object_delete_marker = true
     }
   }
 }

--- a/buckets.tf
+++ b/buckets.tf
@@ -4,6 +4,15 @@ resource "aws_s3_bucket" "bucket" {
   tags          = local.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   bucket = aws_s3_bucket.bucket.id
 

--- a/buckets.tf
+++ b/buckets.tf
@@ -62,16 +62,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
     }
 
     expiration {
-      days = var.log_expiry_days
+      days                         = var.log_expiry_days
+      expired_object_delete_marker = true
     }
 
     # Remove prior object versions after this many days to prevent unbounded growth
     noncurrent_version_expiration {
       noncurrent_days = var.log_version_days
     }
-
-    # Remove delete markers once all noncurrent versions are expired
-    expired_object_delete_marker = true
 
     # Abort incomplete multipart uploads (partial files) after this many days
     abort_incomplete_multipart_upload {

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,7 @@
-data "aws_ami" "amazon_linux_2" {
+data "aws_ami" "amazon_linux" {
   most_recent = true
   owners      = ["amazon"]
-  name_regex  = "^amzn2-ami-hvm.*-ebs"
+  name_regex  = "^al2023-ami-.*-x86_64"
 
   filter {
     name   = "architecture"
@@ -18,7 +18,7 @@ data "aws_ami" "custom_ami" {
 }
 
 locals {
-  bastion_ami = var.bastion_ami == "" ? data.aws_ami.amazon_linux_2 : data.aws_ami.custom_ami[0]
+  bastion_ami = var.bastion_ami == "" ? data.aws_ami.amazon_linux : data.aws_ami.custom_ami[0]
 }
 
 data "aws_subnet" "subnets" {

--- a/main.tf
+++ b/main.tf
@@ -96,8 +96,7 @@ data "aws_iam_policy_document" "bastion_host_policy_document" {
 
   statement {
     actions = [
-      "s3:PutObject",
-      "s3:PutObjectAcl"
+      "s3:PutObject"
     ]
     resources = ["${aws_s3_bucket.bucket.arn}/logs/*"]
   }
@@ -234,6 +233,7 @@ resource "aws_launch_template" "bastion_launch_template" {
     extra_user_data_content = var.extra_user_data_content
     allow_ssh_commands      = lower(var.allow_ssh_commands)
     public_ssh_port         = var.public_ssh_port
+    bastion_ssh_user        = var.bastion_ssh_user
     sync_logs_cron_job      = var.enable_logs_s3_sync ? "*/5 * * * * /usr/bin/bastion/sync_s3" : ""
   }))
 

--- a/providers.tf
+++ b/providers.tf
@@ -6,5 +6,5 @@ terraform {
     }
   }
 
-  required_version = "~> 1.0"
+  required_version = ">= 1.2.4"
 }

--- a/user_data.sh
+++ b/user_data.sh
@@ -7,8 +7,8 @@
 # Create a new folder for the log files
 mkdir /var/log/bastion
 
-# Allow ubuntu only to access this folder and its content
-chown ubuntu:ubuntu /var/log/bastion
+# Allow the bastion SSH user only to access this folder and its content
+chown ${bastion_ssh_user}:${bastion_ssh_user} /var/log/bastion
 chmod -R 770 /var/log/bastion
 setfacl -Rdm other:0 /var/log/bastion
 
@@ -69,7 +69,7 @@ chmod a+x /usr/bin/bastion/shell
 # 1. Add a random suffix to the log file name.
 # 2. Prevent bastion host users from listing the folder containing log files. This is done
 #    by changing the group owner of "script" and setting GID.
-chown root:ubuntu /usr/bin/script
+chown root:${bastion_ssh_user} /usr/bin/script
 chmod g+s /usr/bin/script
 
 # 3. Prevent bastion host users from viewing processes owned by other users, because the log

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "bastion_security_group_id" {
   default     = ""
 }
 
+variable "bastion_ssh_user" {
+  type        = string
+  description = "Default SSH user for the bastion AMI (e.g. ec2-user for Amazon Linux, ubuntu for Ubuntu)"
+  default     = "ubuntu"
+}
+
 variable "bucket_force_destroy" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,18 @@ variable "log_standard_ia_days" {
   default     = 30
 }
 
+variable "log_version_days" {
+  type        = number
+  description = "Number of days before removing previous versions of logs"
+  default     = 30
+}
+
+variable "log_incomplete_multipart_days" {
+  type        = number
+  description = "Number of days after which incomplete multipart uploads (partial files) are aborted and cleaned up"
+  default     = 7
+}
+
 variable "name" {
   type        = string
   description = "Default name to use for resources"


### PR DESCRIPTION
## Issues Closed

- PARA-16993

## Brief Summary

Bastion S3 bucket policy improvements.

## Detailed Summary

Removes deprecated S3 ACL usage. Adds S3 management policies to remove old versions of files and incomplete uploads for cost savings. Changed default AMI from AL2 to AL2023.

## Changes

- terraform S3 policies
- terraform AMI selection
- docs